### PR TITLE
Fix rememberOnRoute to take in key if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,10 @@ fun ListDetailScreen() {
 @Composable
 fun DetailsScreen(detail: String) {
   // 📦 Scope an instance (a view model, a state-holder or whatever) to a route with [rememberOnRoute] 
-  //   1. Makes your instances survive configuration changes (on android) 🔁
-  //   2. Holds-on the instance as long as it is in the backstack 🔗
-  val instance: DetailInstance = rememberOnRoute { savedState -> DetailInstance(savedState, detail) }
+  // This makes your instances survive configuration changes (on android) 🔁
+  // And holds-on the instance as long as it is in the backstack 🔗
+  // Pass in key if you want to reissue a new instance when key changes 🔑 (optional) 
+  val instance: DetailInstance = rememberOnRoute(key = detail) { savedState -> DetailInstance(savedState, detail) }
   
   val state: DetailState by instance.states.collectAsState()
   Text(text = state.detail)

--- a/decompose-router/api/android/decompose-router.api
+++ b/decompose-router/api/android/decompose-router.api
@@ -13,7 +13,7 @@ public final class io/github/xxfast/decompose/router/Router : com/arkivanov/deco
 
 public final class io/github/xxfast/decompose/router/RouterKt {
 	public static final fun getLocalRouter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
-	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
+	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
 	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
 }
 

--- a/decompose-router/api/desktop/decompose-router.api
+++ b/decompose-router/api/desktop/decompose-router.api
@@ -13,7 +13,7 @@ public final class io/github/xxfast/decompose/router/Router : com/arkivanov/deco
 
 public final class io/github/xxfast/decompose/router/RouterKt {
 	public static final fun getLocalRouter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
-	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
+	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
 	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
 }
 

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Router.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Router.kt
@@ -70,12 +70,14 @@ fun <C : Parcelable> rememberRouter(
  * Creates a instance of [T] that is scoped to the current route
  *
  * @param instanceClass class of [T] instance
+ * @param key key to remember the instance with. Defaults to [instanceClass]
  * @param block lambda to create an instance of [T] with a given [SavedStateHandle]
  */
 @Suppress("UNCHECKED_CAST")
 @Composable
 fun <T : Instance> rememberOnRoute(
   instanceClass: KClass<T>,
+  key: Any = instanceClass,
   block: @DisallowComposableCalls (savedState: SavedStateHandle) -> T
 ): T {
   val component: ComponentContext = LocalComponentContext.current
@@ -87,7 +89,7 @@ fun <T : Instance> rememberOnRoute(
   val instanceKey = "$packageName.instance"
   val stateKey = "$packageName.savedState"
 
-  val (instance, savedState) = remember(instanceClass) {
+  val (instance, savedState) = remember(key) {
     val savedState: SavedStateHandle = instanceKeeper
       .getOrCreate(stateKey) { SavedStateHandle(stateKeeper.consume(stateKey, SavedState::class)) }
     var instance: T? = instanceKeeper.get(instanceKey) as T?


### PR DESCRIPTION
This allows you to reissue instances/viewmodels based on a key. Useful if you want to swap out a instances/viewmodels without having to reopen the screen