### PR TITLE
Fix remove simpleName for the key as it fails with proguard on Android

### DIFF
--- a/decompose-router/api/android/decompose-router.api
+++ b/decompose-router/api/android/decompose-router.api
@@ -14,7 +14,7 @@ public final class io/github/xxfast/decompose/router/Router : com/arkivanov/deco
 public final class io/github/xxfast/decompose/router/RouterKt {
 	public static final fun getLocalRouter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
 }
 
 public final class io/github/xxfast/decompose/router/SavedState : android/os/Parcelable {

--- a/decompose-router/api/desktop/decompose-router.api
+++ b/decompose-router/api/desktop/decompose-router.api
@@ -14,7 +14,7 @@ public final class io/github/xxfast/decompose/router/Router : com/arkivanov/deco
 public final class io/github/xxfast/decompose/router/RouterKt {
 	public static final fun getLocalRouter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
 }
 
 public final class io/github/xxfast/decompose/router/SavedState : com/arkivanov/essenty/parcelable/Parcelable {

--- a/decompose-router/src/androidMain/kotlin/io/github/xxfast/decompose/router/Key.kt
+++ b/decompose-router/src/androidMain/kotlin/io/github/xxfast/decompose/router/Key.kt
@@ -1,0 +1,6 @@
+package io.github.xxfast.decompose.router
+
+import kotlin.reflect.KClass
+
+internal actual val KClass<*>.key: String get() =
+  requireNotNull(qualifiedName) { "Unable to use name of $this as the default key"}

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Key.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Key.kt
@@ -1,0 +1,5 @@
+package io.github.xxfast.decompose.router
+
+import kotlin.reflect.KClass
+
+internal expect val KClass<*>.key: String

--- a/decompose-router/src/desktopMain/kotlin/io/github/xxfast/decompose/router/Key.kt
+++ b/decompose-router/src/desktopMain/kotlin/io/github/xxfast/decompose/router/Key.kt
@@ -1,0 +1,6 @@
+package io.github.xxfast.decompose.router
+
+import kotlin.reflect.KClass
+
+internal actual val KClass<*>.key: String get() =
+  requireNotNull(qualifiedName) { "Unable to use name of $this as the default key"}

--- a/decompose-router/src/iosMain/kotlin/io/github/xxfast/decompose/router/Key.kt
+++ b/decompose-router/src/iosMain/kotlin/io/github/xxfast/decompose/router/Key.kt
@@ -1,0 +1,6 @@
+package io.github.xxfast.decompose.router
+
+import kotlin.reflect.KClass
+
+internal actual val KClass<*>.key: String get() =
+  requireNotNull(qualifiedName) { "Unable to use name of $this as the default key"}

--- a/decompose-router/src/jsMain/kotlin/io/github/xxfast/decompose/router/Key.kt
+++ b/decompose-router/src/jsMain/kotlin/io/github/xxfast/decompose/router/Key.kt
@@ -1,0 +1,7 @@
+package io.github.xxfast.decompose.router
+
+import kotlin.reflect.KClass
+
+// TODO: Given that we don't have tree-shaking on js - yet, should be safe to use simpleName here
+internal actual val KClass<*>.key: String get() =
+  requireNotNull(simpleName) { "Unable to use name of $this as the default key"}


### PR DESCRIPTION
There's a chance that the `simpleName` can clash after minification on android - so we need to use a fully qualified name as the key. However, this is not available on js. For now, I'm still using the `simpleName` but just for JS