### PR TITLE
Refactor router api to mirror decompose api

### DIFF
--- a/decompose-router/api/android/decompose-router.api
+++ b/decompose-router/api/android/decompose-router.api
@@ -29,7 +29,7 @@ public final class io/github/xxfast/decompose/router/RouterContextKt {
 public final class io/github/xxfast/decompose/router/RouterKt {
 	public static final fun getLocalRouter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
 }
 
 public final class io/github/xxfast/decompose/router/SavedState : android/os/Parcelable {

--- a/decompose-router/api/desktop/decompose-router.api
+++ b/decompose-router/api/desktop/decompose-router.api
@@ -24,7 +24,7 @@ public final class io/github/xxfast/decompose/router/RouterContextKt {
 public final class io/github/xxfast/decompose/router/RouterKt {
 	public static final fun getLocalRouter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun rememberOnRoute (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/Router;
 }
 
 public final class io/github/xxfast/decompose/router/SavedState : com/arkivanov/essenty/parcelable/Parcelable {

--- a/decompose-router/src/androidInstrumentedTest/kotlin/io/github/xxfast/decompose/screen/HomeScreen.kt
+++ b/decompose-router/src/androidInstrumentedTest/kotlin/io/github/xxfast/decompose/screen/HomeScreen.kt
@@ -18,8 +18,7 @@ import io.github.xxfast.decompose.screen.nested.NestedScreen
 @OptIn(ExperimentalDecomposeApi::class)
 @Composable
 fun HomeScreen() {
-  val router: Router<HomeScreens> =
-    rememberRouter(HomeScreens::class, stack = listOf(HomeScreens.List))
+  val router: Router<HomeScreens> = rememberRouter(HomeScreens::class) { listOf(HomeScreens.List) }
 
   RoutedContent(
     router = router,

--- a/decompose-router/src/androidInstrumentedTest/kotlin/io/github/xxfast/decompose/screen/nested/NestedScreen.kt
+++ b/decompose-router/src/androidInstrumentedTest/kotlin/io/github/xxfast/decompose/screen/nested/NestedScreen.kt
@@ -55,7 +55,7 @@ fun NestedScreen(
   onBack: () -> Unit,
   onSelect: (Int) -> Unit
 ) {
-  val router: Router<NestedScreens> = rememberRouter(NestedScreens::class, stack = listOf(Home))
+  val router: Router<NestedScreens> = rememberRouter(NestedScreens::class) { listOf(Home) }
 
   val items: List<Int> = buildList { repeat(50) { add(it) } }
 


### PR DESCRIPTION
Aligning the parameter names of public API signatures with those of decompose to make things more consistent with the parent library 