### PR TITLE
Fix value subscription on ios and web targets

### DIFF
--- a/decompose-router/src/androidMain/kotlin/io/github/xxfast/decompose/router/Value.kt
+++ b/decompose-router/src/androidMain/kotlin/io/github/xxfast/decompose/router/Value.kt
@@ -1,0 +1,16 @@
+package io.github.xxfast.decompose.router
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.observe
+import com.arkivanov.essenty.lifecycle.Lifecycle
+
+@Composable
+internal actual fun <T : Any> Value<T>.subscribeAsState(lifecycle: Lifecycle): State<T> {
+  val state = remember { mutableStateOf(value) }
+  observe(lifecycle = lifecycle) { state.value = it }
+  return state
+}

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/ChildStack.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/ChildStack.kt
@@ -2,14 +2,10 @@ package io.github.xxfast.decompose.router
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigationSource
 import com.arkivanov.decompose.router.stack.childStack
-import com.arkivanov.decompose.value.Value
-import com.arkivanov.decompose.value.observe
-import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.parcelable.Parcelable
 import kotlin.reflect.KClass
 
@@ -34,11 +30,5 @@ internal fun <C : Parcelable> RouterContext.rememberChildStack(
       )
     }
   }
-    .asState(lifecycle)
-}
-
-private fun <T : Any> Value<T>.asState(lifecycle: Lifecycle): State<T> {
-  val state = mutableStateOf(value)
-  observe(lifecycle = lifecycle) { state.value = it }
-  return state
+  .subscribeAsState(lifecycle)
 }

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/ChildStack.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/ChildStack.kt
@@ -1,0 +1,44 @@
+package io.github.xxfast.decompose.router
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.router.stack.StackNavigationSource
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.observe
+import com.arkivanov.essenty.lifecycle.Lifecycle
+import com.arkivanov.essenty.parcelable.Parcelable
+import kotlin.reflect.KClass
+
+@Composable
+internal fun <C : Parcelable> RouterContext.rememberChildStack(
+  type: KClass<C>,
+  key: Any,
+  navigation: StackNavigationSource<C>,
+  handleBackButton: Boolean = true,
+  initialStack: () -> List<C>,
+): State<ChildStack<C, RouterContext>> {
+  val stackKey = "$key.stack"
+  return remember(stackKey) {
+    getOrCreate(key = stackKey) {
+      childStack(
+        source = navigation,
+        initialStack = initialStack,
+        configurationClass = type,
+        key = stackKey,
+        handleBackButton = handleBackButton,
+        childFactory = { _, childComponentContext -> RouterContext(childComponentContext) },
+      )
+    }
+  }
+    .asState(lifecycle)
+}
+
+private fun <T : Any> Value<T>.asState(lifecycle: Lifecycle): State<T> {
+  val state = mutableStateOf(value)
+  observe(lifecycle = lifecycle) { state.value = it }
+  return state
+}

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Navigation.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Navigation.kt
@@ -1,0 +1,13 @@
+package io.github.xxfast.decompose.router
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.arkivanov.decompose.router.stack.StackNavigation
+
+@Composable
+internal fun <C: Any> RouterContext.rememberNavigation(
+  key: Any,
+) : StackNavigation<C> {
+  val navigationKey = "$key.navigation"
+  return remember(navigationKey) { getOrCreate(key = navigationKey) { StackNavigation() } }
+}

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Value.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/Value.kt
@@ -1,0 +1,9 @@
+package io.github.xxfast.decompose.router
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.lifecycle.Lifecycle
+
+@Composable
+internal expect fun <T : Any> Value<T>.subscribeAsState(lifecycle: Lifecycle): State<T>

--- a/decompose-router/src/desktopMain/kotlin/io/github/xxfast/decompose/router/Value.kt
+++ b/decompose-router/src/desktopMain/kotlin/io/github/xxfast/decompose/router/Value.kt
@@ -1,0 +1,16 @@
+package io.github.xxfast.decompose.router
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.observe
+import com.arkivanov.essenty.lifecycle.Lifecycle
+
+@Composable
+internal actual fun <T : Any> Value<T>.subscribeAsState(lifecycle: Lifecycle): State<T> {
+  val state = remember { mutableStateOf(value) }
+  observe(lifecycle = lifecycle) { state.value = it }
+  return state
+}

--- a/decompose-router/src/iosMain/kotlin/io/github/xxfast/decompose/router/Value.kt
+++ b/decompose-router/src/iosMain/kotlin/io/github/xxfast/decompose/router/Value.kt
@@ -1,0 +1,11 @@
+package io.github.xxfast.decompose.router
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.lifecycle.Lifecycle
+
+@Composable
+internal actual fun <T : Any> Value<T>.subscribeAsState(lifecycle: Lifecycle): State<T> =
+  subscribeAsState()

--- a/decompose-router/src/jsMain/kotlin/io/github/xxfast/decompose/router/Value.kt
+++ b/decompose-router/src/jsMain/kotlin/io/github/xxfast/decompose/router/Value.kt
@@ -1,0 +1,11 @@
+package io.github.xxfast.decompose.router
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.lifecycle.Lifecycle
+
+@Composable
+internal actual fun <T : Any> Value<T>.subscribeAsState(lifecycle: Lifecycle): State<T> =
+  subscribeAsState()


### PR DESCRIPTION
Hi @arkivanov. I think #59 broke the router for both iOS and the Web targets. I was able to pinpoint the issue down to how the `Value`s are subscribed as `State` in [this](https://github.com/xxfast/Decompose-Router/pull/59/files#diff-f3fb1db705c2d79c8004435bca4c0a5f26ed6dc126301786788a43f43793ae5cR77) extension function
```kotlin
private fun <T : Any> Value<T>.asState(lifecycle: Lifecycle): State<T> {
  val state = mutableStateOf(value)
  observe(lifecycle = lifecycle) { state.value = it }
  return state
}
```

This works for both Android and Desktop, but not on iOS and Web for some unknown reason. 

For now, I was able to fix it temporarily with `expect`/`actual`  for ios and web to fall back to the previous approach with `subscribeAsAState`.  But this still introduces the issue of the nested router failing to navigate upon returning back. 

## Before 

https://github.com/xxfast/Decompose-Router/assets/13775137/4527a42b-1c93-4e47-a9b9-bfbebbce79de

## After


https://github.com/xxfast/Decompose-Router/assets/13775137/2b0f8cde-eb18-4f9d-be0c-8913eaf80771



This PR will
- [x] Refactor child stack and navigation out of router
- [x] Fix value subscription for ios and web with `expect`/`actual`