### PR TITLE
Add default router context for ios targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,19 +214,21 @@ class DetailInstance(savedState: SavedStateHandle, detail: String) : InstanceKee
 <details>
   <summary>iOS</summary>
 
-**build.gradle.kts**
+  Make sure to create your root router context outside of `ComposeUIViewController`'s composable lambda and pass it in to `LocalRouterContext` 
+
+  **build.gradle.kts**
   ```kotlin
-  fun main(): UIViewController = ComposeUIViewController {
-    val lifecycle = LifecycleRegistry()
-    val rootRouterContext = RouterContext(lifecycle = lifecycle)
+  fun MainUIController(rootRouterContext: RouterContext): UIViewController = ComposeUIViewController {
     CompositionLocalProvider(LocalRouterContext provides rootRouterContext) {
       MaterialTheme {
         ListDetailScreen()
       }
     }
   }
-
   ```
+  > [!IMPORTANT]
+  > You will need to tie root `RouterContext`'s lifecycle to an `AppDelegate`. See example kotlin app delegate [here](https://github.com/xxfast/Decompose-Router/blob/main/app/src/iosMain/kotlin/io/github/xxfast/decompose/router/app/AppDelegate.kt), or swift delegate [here](https://github.com/xxfast/Decompose-Router/blob/main/app/ios/ios/AppDelegate.swift). Read more on the docs [here](https://arkivanov.github.io/Decompose/getting-started/quick-start/#ios-with-swiftui)
+
 </details>
 
 <details>

--- a/app/ios/ios/AppDelegate.swift
+++ b/app/ios/ios/AppDelegate.swift
@@ -5,12 +5,27 @@ import app
 class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
   
+  var rootRouterContext = RouterContextKt.defaultRouterContext()
+  
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     window = UIWindow(frame: UIScreen.main.bounds)
-    let mainViewController = ApplicationKt.Main()
+    let mainViewController = ApplicationKt.MainUIController(routerContext: rootRouterContext)
     window?.rootViewController = mainViewController
     window?.makeKeyAndVisible()
     return true
+  }
+  
+  
+  func applicationDidBecomeActive(_ application: UIApplication) {
+    RouterContextKt.resume(rootRouterContext.lifecycle)
+  }
+  
+  func applicationWillResignActive(_ application: UIApplication) {
+    RouterContextKt.stop(rootRouterContext.lifecycle)
+  }
+  
+  func applicationWillTerminate(_ application: UIApplication) {
+    RouterContextKt.destroy(rootRouterContext.lifecycle)
   }
 }
 

--- a/app/src/iosMain/kotlin/io/github/xxfast/decompose/router/app/AppDelegate.kt
+++ b/app/src/iosMain/kotlin/io/github/xxfast/decompose/router/app/AppDelegate.kt
@@ -1,11 +1,11 @@
 package io.github.xxfast.decompose.router.app
 
-import com.arkivanov.essenty.backhandler.BackDispatcher
-import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.destroy
 import com.arkivanov.essenty.lifecycle.resume
 import com.arkivanov.essenty.lifecycle.stop
 import io.github.xxfast.decompose.router.RouterContext
+import io.github.xxfast.decompose.router.app.utils.registry
+import io.github.xxfast.decompose.router.defaultRouterContext
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIApplication
@@ -20,13 +20,7 @@ import platform.UIKit.UIWindow
 class AppDelegate @OverrideInit constructor() : UIResponder(), UIApplicationDelegateProtocol {
   companion object : UIResponderMeta(), UIApplicationDelegateProtocolMeta
 
-  private val backDispatcher = BackDispatcher()
-  private val lifecycle = LifecycleRegistry()
-
-  private val routerContext = RouterContext(
-    lifecycle = lifecycle,
-    backHandler = backDispatcher
-  )
+  private val routerContext: RouterContext = defaultRouterContext()
 
   private var _window: UIWindow? = null
   override fun window() = _window
@@ -46,15 +40,14 @@ class AppDelegate @OverrideInit constructor() : UIResponder(), UIApplicationDele
   }
 
   override fun applicationDidBecomeActive(application: UIApplication) {
-    lifecycle.resume()
+    routerContext.lifecycle.registry.resume()
   }
 
   override fun applicationWillResignActive(application: UIApplication) {
-    lifecycle.stop()
-
+    routerContext.lifecycle.registry.stop()
   }
 
   override fun applicationWillTerminate(application: UIApplication) {
-    lifecycle.destroy()
+    routerContext.lifecycle.registry.destroy()
   }
 }

--- a/app/src/iosMain/kotlin/io/github/xxfast/decompose/router/app/Application.kt
+++ b/app/src/iosMain/kotlin/io/github/xxfast/decompose/router/app/Application.kt
@@ -37,24 +37,22 @@ fun main() {
 }
 
 @OptIn(ExperimentalDecomposeApi::class)
-fun MainUIController(routerContext: RouterContext): UIViewController {
-  return ComposeUIViewController {
-    CompositionLocalProvider(
-      LocalRouterContext provides routerContext,
-    ) {
-      MaterialTheme {
-        PredictiveBackGestureOverlay(
-          backDispatcher = routerContext.backHandler as BackDispatcher, // Use the same BackDispatcher as above
-          backIcon = { progress, _ ->
-            PredictiveBackGestureIcon(
-              imageVector = Icons.Default.ArrowBack,
-              progress = progress,
-            )
-          },
-          modifier = Modifier.fillMaxSize(),
-        ) {
-          HomeScreen()
-        }
+fun MainUIController(routerContext: RouterContext): UIViewController = ComposeUIViewController {
+  CompositionLocalProvider(
+    LocalRouterContext provides routerContext,
+  ) {
+    MaterialTheme {
+      PredictiveBackGestureOverlay(
+        backDispatcher = routerContext.backHandler as BackDispatcher, // Use the same BackDispatcher as above
+        backIcon = { progress, _ ->
+          PredictiveBackGestureIcon(
+            imageVector = Icons.Default.ArrowBack,
+            progress = progress,
+          )
+        },
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        HomeScreen()
       }
     }
   }

--- a/app/src/iosMain/kotlin/io/github/xxfast/decompose/router/app/utils/RouterContext.kt
+++ b/app/src/iosMain/kotlin/io/github/xxfast/decompose/router/app/utils/RouterContext.kt
@@ -1,0 +1,15 @@
+package io.github.xxfast.decompose.router.app.utils
+
+import com.arkivanov.essenty.lifecycle.Lifecycle
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.destroy
+import com.arkivanov.essenty.lifecycle.resume
+import com.arkivanov.essenty.lifecycle.stop
+import io.github.xxfast.decompose.router.RouterContext
+import io.github.xxfast.decompose.router.defaultRouterContext
+
+fun defaultRouterContext(): RouterContext = defaultRouterContext()
+val Lifecycle.registry get() = this as LifecycleRegistry
+fun Lifecycle.destroy() = registry.destroy()
+fun Lifecycle.resume() = registry.resume()
+fun Lifecycle.stop() = registry.stop()

--- a/decompose-router/src/iosMain/kotlin/io/github/xxfast/decompose/router/RouterContext.kt
+++ b/decompose-router/src/iosMain/kotlin/io/github/xxfast/decompose/router/RouterContext.kt
@@ -1,0 +1,11 @@
+package io.github.xxfast.decompose.router
+
+import com.arkivanov.essenty.backhandler.BackDispatcher
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+
+fun defaultRouterContext(): RouterContext {
+  val backDispatcher = BackDispatcher()
+  val lifecycle = LifecycleRegistry()
+  return RouterContext(lifecycle = lifecycle, backHandler = backDispatcher)
+}
+


### PR DESCRIPTION
convenience extensions for ios targets to help set up the root router context correctly  