### PR TITLE
Allow router to consume custom serializers

### DIFF
--- a/decompose-router/api/android/decompose-router.api
+++ b/decompose-router/api/android/decompose-router.api
@@ -51,7 +51,7 @@ public final class io/github/xxfast/decompose/router/pages/Router : com/arkivano
 public final class io/github/xxfast/decompose/router/pages/RouterKt {
 	public static final fun pagesOf ([Ljava/lang/Object;I)Lcom/arkivanov/decompose/router/pages/Pages;
 	public static synthetic fun pagesOf$default ([Ljava/lang/Object;IILjava/lang/Object;)Lcom/arkivanov/decompose/router/pages/Pages;
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/pages/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/pages/Router;
 }
 
 public final class io/github/xxfast/decompose/router/slot/RoutedContentKt {
@@ -68,7 +68,7 @@ public final class io/github/xxfast/decompose/router/slot/Router : com/arkivanov
 }
 
 public final class io/github/xxfast/decompose/router/slot/RouterKt {
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/slot/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/slot/Router;
 }
 
 public final class io/github/xxfast/decompose/router/stack/RoutedContentKt {
@@ -84,6 +84,6 @@ public final class io/github/xxfast/decompose/router/stack/Router : com/arkivano
 }
 
 public final class io/github/xxfast/decompose/router/stack/RouterKt {
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/stack/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/stack/Router;
 }
 

--- a/decompose-router/api/desktop/decompose-router.api
+++ b/decompose-router/api/desktop/decompose-router.api
@@ -50,7 +50,7 @@ public final class io/github/xxfast/decompose/router/pages/Router : com/arkivano
 public final class io/github/xxfast/decompose/router/pages/RouterKt {
 	public static final fun pagesOf ([Ljava/lang/Object;I)Lcom/arkivanov/decompose/router/pages/Pages;
 	public static synthetic fun pagesOf$default ([Ljava/lang/Object;IILjava/lang/Object;)Lcom/arkivanov/decompose/router/pages/Pages;
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/pages/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/pages/Router;
 }
 
 public final class io/github/xxfast/decompose/router/slot/RoutedContentKt {
@@ -67,7 +67,7 @@ public final class io/github/xxfast/decompose/router/slot/Router : com/arkivanov
 }
 
 public final class io/github/xxfast/decompose/router/slot/RouterKt {
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/slot/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/slot/Router;
 }
 
 public final class io/github/xxfast/decompose/router/stack/RoutedContentKt {
@@ -83,6 +83,6 @@ public final class io/github/xxfast/decompose/router/stack/Router : com/arkivano
 }
 
 public final class io/github/xxfast/decompose/router/stack/RouterKt {
-	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/stack/Router;
+	public static final fun rememberRouter (Lkotlin/reflect/KClass;Ljava/lang/Object;ZLkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/xxfast/decompose/router/stack/Router;
 }
 

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/pages/Router.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/pages/Router.kt
@@ -14,6 +14,7 @@ import io.github.xxfast.decompose.asState
 import io.github.xxfast.decompose.router.getOrCreate
 import io.github.xxfast.decompose.key
 import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KClass
@@ -30,6 +31,7 @@ fun <C: @Serializable Any> rememberRouter(
   type: KClass<C>,
   key: Any = type.key,
   handleBackButton: Boolean = true,
+  serializer: KSerializer<C>? = type.serializerOrNull(),
   initialPages: () -> Pages<C>,
 ): Router<C> {
   val routerContext: RouterContext = LocalRouterContext.current
@@ -41,7 +43,7 @@ fun <C: @Serializable Any> rememberRouter(
       val stack: State<ChildPages<C, RouterContext>> = routerContext
         .childPages(
           source = navigation,
-          serializer = type.serializerOrNull(),
+          serializer = serializer,
           initialPages = initialPages,
           key = routerKey,
           handleBackButton = handleBackButton,

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/slot/Router.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/slot/Router.kt
@@ -12,6 +12,7 @@ import io.github.xxfast.decompose.router.LocalRouterContext
 import io.github.xxfast.decompose.router.RouterContext
 import io.github.xxfast.decompose.router.getOrCreate
 import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KClass
@@ -27,6 +28,7 @@ fun <C : @Serializable Any> rememberRouter(
   type: KClass<C>,
   key: Any = type.key,
   handleBackButton: Boolean = true,
+  serializer: KSerializer<C>? = type.serializerOrNull(),
   initialConfiguration: () -> C?,
 ): Router<C> {
   val routerContext: RouterContext = LocalRouterContext.current
@@ -38,7 +40,7 @@ fun <C : @Serializable Any> rememberRouter(
       val slot: State<ChildSlot<C, RouterContext>> = routerContext
         .childSlot(
           source = navigation,
-          serializer = type.serializerOrNull(),
+          serializer = serializer,
           initialConfiguration = initialConfiguration,
           key = routerKey,
           handleBackButton = handleBackButton,

--- a/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/stack/Router.kt
+++ b/decompose-router/src/commonMain/kotlin/io/github/xxfast/decompose/router/stack/Router.kt
@@ -48,6 +48,7 @@ fun <C: @Serializable Any> rememberRouter(
   type: KClass<C>,
   key: Any = type.key,
   handleBackButton: Boolean = true,
+  serializer: KSerializer<C>? = type.serializerOrNull(),
   initialStack: () -> List<C>,
 ): Router<C> {
   val routerContext: RouterContext = LocalRouterContext.current
@@ -59,7 +60,7 @@ fun <C: @Serializable Any> rememberRouter(
       val stack: State<ChildStack<C, RouterContext>> = routerContext
         .childStack(
           source = navigation,
-          serializer = type.serializerOrNull(),
+          serializer = serializer,
           initialStack = initialStack,
           key = routerKey,
           handleBackButton = handleBackButton,


### PR DESCRIPTION
This allows routers to restore any state with custom serialisers provided via a serializer module